### PR TITLE
Pin build numpy [ci skip] [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - toolchain
     - astropy >=2.0
     - ephem
-    - numpy >=1.11
+    - numpy 1.11.*
     - python <3
     - setuptools
 


### PR DESCRIPTION
Always build against numpy 1.11 so that one package has the broadest range of binary compatibility (given that we require numpy 1.11 at runtime, I think because previous versions have a bug that bites us).