### PR TITLE
Issue a new build to fix the numpy problem

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=files.txt
   skip: true  # [win or py3k]
 


### PR DESCRIPTION
It's popping up in practice because aipy is sometimes used with healpy, which pins its numpy version.